### PR TITLE
Sort namespace declarations alphabetically by prefix

### DIFF
--- a/pyxb/utils/domutils.py
+++ b/pyxb/utils/domutils.py
@@ -457,7 +457,7 @@ class BindingDOMSupport (object):
         ns = self.defaultNamespace()
         if ns is not None:
             self.addXMLNSDeclaration(self.document().documentElement, ns, '')
-        for (ns, pfx) in self.__referencedNamespacePrefixes:
+        for (ns, pfx) in sorted(self.__referencedNamespacePrefixes, key=lambda ns_pfx: ns_pfx[1]):
             self.addXMLNSDeclaration(self.document().documentElement, ns, pfx)
         return self.document()
 


### PR DESCRIPTION
Otherwise, the order of namespace declarations is unstable (different for every run),
which makes it hard to write tests that compare generated XML against expected XML
documents.